### PR TITLE
Fix filter template display issues; update .gitignore to exclude venv/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ local_settings.py
 db.sqlite3
 media
 
+### Django secrets ###
+**/secrets.py
+
 ### Intellij ###
 .idea/
 *.iml
@@ -79,17 +82,11 @@ target/
 .ipynb_checkpoints
 
 # Environments
-yelpEnv/
-yelpEnv.bak/
-
-# Django Secrets
-**/secrets.py
+venv/
+venv.bak/
 
 # mkdocs documentation
 /site
-
-# VS Code
-.vscode/
 
 # mypy
 .mypy_cache/

--- a/yelp/templates/yelp/user_filter.html
+++ b/yelp/templates/yelp/user_filter.html
@@ -42,32 +42,3 @@
     </div>
   </div>
 {% endblock content %}
-
-
-<div class="row">
-  <div class="col-sm-3">
-    <div class="px-2 py-2" style="border:1px solid #8E8D8A;">
-      <form action="" method="get">
-        {{ filter.form|crispy }}
-        <!-- {{ filter.form.as_p }} -->
-        <button type="submit" class="btn btn-outline-primary">filter</button>
-      </form>
-    </div>
-  </div>
-  <div class="col-sm-9">
-
-    {% include 'heritagesites/pagination.html' %}
-
-    {% for site in site_list %}
-    <h4><a href="{% url 'site_detail' site.pk %}">{{ site.site_name|safe }}</a></h4>
-    {% if site.country_area_names %}
-    <p>{{ site.country_area_names }}</p>
-    {% endif %}
-    {% if site.description %}
-    {{ site.description | safe }}
-    {% endif %}
-    {% empty %}
-    Select one or more filters relevant to your search and then click "filter".
-    {% endfor %}
-  </div>
-</div>

--- a/yelp/templates/yelp/user_filter.html
+++ b/yelp/templates/yelp/user_filter.html
@@ -16,6 +16,7 @@
       </div>
     </div>
   </header>
+
   <div class="row">
     <div class="col-sm-3">
       <div class="px-2 py-2" style="border:1px solid #8E8D8A;">
@@ -33,12 +34,40 @@
             <div class="col-sm-9">
               <p>{{ user.business_names | safe }}</p>
             </div>
+          </div>
         {% endif %}
-        </div>
-      </div>
     {% empty %}
       Select one or more filters relevant to your search and then click "filter".
     {% endfor %}
     </div>
   </div>
 {% endblock content %}
+
+
+<div class="row">
+  <div class="col-sm-3">
+    <div class="px-2 py-2" style="border:1px solid #8E8D8A;">
+      <form action="" method="get">
+        {{ filter.form|crispy }}
+        <!-- {{ filter.form.as_p }} -->
+        <button type="submit" class="btn btn-outline-primary">filter</button>
+      </form>
+    </div>
+  </div>
+  <div class="col-sm-9">
+
+    {% include 'heritagesites/pagination.html' %}
+
+    {% for site in site_list %}
+    <h4><a href="{% url 'site_detail' site.pk %}">{{ site.site_name|safe }}</a></h4>
+    {% if site.country_area_names %}
+    <p>{{ site.country_area_names }}</p>
+    {% endif %}
+    {% if site.description %}
+    {{ site.description | safe }}
+    {% endif %}
+    {% empty %}
+    Select one or more filters relevant to your search and then click "filter".
+    {% endfor %}
+  </div>
+</div>


### PR DESCRIPTION
This PR fixes issues with `<div>` tags in the user filter template.  It also updates the .gitignore to exclude `venv/` directory and the `secrets.py` file.

### From

![image](https://user-images.githubusercontent.com/83268/50356764-46b77a80-0521-11e9-8b78-1db650e1bc68.png)

### To

![image](https://user-images.githubusercontent.com/83268/50356783-56cf5a00-0521-11e9-8004-38bbe01c26d3.png)



